### PR TITLE
難易度選択機能を追加

### DIFF
--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -1,12 +1,21 @@
+import { useState } from 'react';
+import { DifficultyFilter } from '../types';
+
 interface StartScreenProps {
-  onStart: () => void;
+  onStart: (difficulty: DifficultyFilter) => void;
 }
 
 export function StartScreen({ onStart }: StartScreenProps) {
+  const [selectedDifficulty, setSelectedDifficulty] = useState<DifficultyFilter>('all');
+
+  const handleStart = () => {
+    onStart(selectedDifficulty);
+  };
+
   return (
     <div className="start-screen">
       <div className="film-strip top" />
-      
+
       <div className="title-container">
         <div className="aperture-icon">
           <div className="aperture-blade" />
@@ -16,23 +25,56 @@ export function StartScreen({ onStart }: StartScreenProps) {
           <div className="aperture-blade" />
           <div className="aperture-blade" />
         </div>
-        
+
         <h1 className="title">
           <span className="title-main">CAMERA</span>
           <span className="title-sub">QUIZ</span>
         </h1>
-        
+
         <p className="description">
-          カメラと写真の雑学クイズ<br />
-          全10問にチャレンジ！
+          カメラと写真の雑学クイズ
         </p>
       </div>
-      
-      <button className="start-button" onClick={onStart}>
+
+      <div className="difficulty-selector">
+        <h3 className="difficulty-title">難易度を選択</h3>
+        <div className="difficulty-options">
+          <button
+            className={`difficulty-option ${selectedDifficulty === 'all' ? 'selected' : ''}`}
+            onClick={() => setSelectedDifficulty('all')}
+          >
+            <span className="difficulty-label">すべて</span>
+            <span className="difficulty-count">30問からランダム</span>
+          </button>
+          <button
+            className={`difficulty-option difficulty-easy ${selectedDifficulty === 1 ? 'selected' : ''}`}
+            onClick={() => setSelectedDifficulty(1)}
+          >
+            <span className="difficulty-label">初級</span>
+            <span className="difficulty-count">12問から出題</span>
+          </button>
+          <button
+            className={`difficulty-option difficulty-medium ${selectedDifficulty === 2 ? 'selected' : ''}`}
+            onClick={() => setSelectedDifficulty(2)}
+          >
+            <span className="difficulty-label">中級</span>
+            <span className="difficulty-count">12問から出題</span>
+          </button>
+          <button
+            className={`difficulty-option difficulty-hard ${selectedDifficulty === 3 ? 'selected' : ''}`}
+            onClick={() => setSelectedDifficulty(3)}
+          >
+            <span className="difficulty-label">上級</span>
+            <span className="difficulty-count">6問すべて出題</span>
+          </button>
+        </div>
+      </div>
+
+      <button className="start-button" onClick={handleStart}>
         <span className="shutter-icon" />
         START
       </button>
-      
+
       <div className="film-strip bottom" />
     </div>
   );

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { Question, QuizState, GamePhase } from '../types';
+import { Question, QuizState, GamePhase, DifficultyFilter } from '../types';
 import questionsData from '../data/questions.json';
 
 const QUESTIONS_PER_GAME = 10;
@@ -24,10 +24,20 @@ export function useQuiz() {
     answers: [],
   });
 
-  const startGame = useCallback(() => {
-    const shuffled = shuffleArray(questionsData as Question[]);
-    const selected = shuffled.slice(0, QUESTIONS_PER_GAME);
-    
+  const startGame = useCallback((difficulty: DifficultyFilter = 'all') => {
+    // 難易度でフィルタリング
+    const allQuestions = questionsData as Question[];
+    const filtered = difficulty === 'all'
+      ? allQuestions
+      : allQuestions.filter(q => q.difficulty === difficulty);
+
+    // シャッフル
+    const shuffled = shuffleArray(filtered);
+
+    // 出題数を決定（利用可能な問題数と10問の少ない方）
+    const count = Math.min(QUESTIONS_PER_GAME, filtered.length);
+    const selected = shuffled.slice(0, count);
+
     setState({
       phase: 'playing',
       questions: selected,

--- a/src/index.css
+++ b/src/index.css
@@ -512,6 +512,85 @@ body {
   font-size: 1.2rem;
 }
 
+/* ========== Difficulty Selector ========== */
+.difficulty-selector {
+  margin: 32px 0;
+  padding: 0 20px;
+}
+
+.difficulty-title {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  text-align: center;
+  margin-bottom: 16px;
+  font-weight: 400;
+  letter-spacing: 1px;
+}
+
+.difficulty-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.difficulty-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 14px 20px;
+  background: var(--bg-dark);
+  border: 2px solid var(--border-subtle);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+  border-radius: 2px;
+}
+
+.difficulty-option:hover {
+  background: var(--bg-card-hover);
+  border-color: var(--accent-gold-dim);
+}
+
+.difficulty-option.selected {
+  background: var(--accent-gold);
+  color: var(--bg-dark);
+  border-color: var(--accent-gold);
+  font-weight: 600;
+}
+
+.difficulty-label {
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 1px;
+}
+
+.difficulty-count {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+.difficulty-option.selected .difficulty-count {
+  opacity: 0.9;
+}
+
+/* Difficulty colors */
+.difficulty-easy.selected {
+  background: #4ade80;
+  border-color: #4ade80;
+}
+
+.difficulty-medium.selected {
+  background: #fbbf24;
+  border-color: #fbbf24;
+}
+
+.difficulty-hard.selected {
+  background: #f87171;
+  border-color: #f87171;
+}
+
 /* ========== Responsive ========== */
 @media (max-width: 480px) {
   .title-main {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export interface Question {
   explanation: string;
 }
 
+export type DifficultyFilter = 'all' | 1 | 2 | 3;
+
 export type GamePhase = 'start' | 'playing' | 'result';
 
 export interface QuizState {


### PR DESCRIPTION
スタート画面で難易度を選択できる機能を実装しました。

追加機能:
- 難易度フィルター（すべて/初級/中級/上級）
- 難易度ごとの問題数表示
  - すべて: 30問からランダムに10問
  - 初級: 12問からランダムに10問
  - 中級: 12問からランダムに10問
  - 上級: 6問すべて出題
- 選択した難易度に応じた色分け表示

技術的な変更:
- DifficultyFilter型を追加
- startGame関数に難易度パラメータを追加
- 難易度選択UIとスタイリングを実装