### PR TITLE
難易度4の表示でクラッシュするバグを修正

### DIFF
--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -22,7 +22,7 @@ export function Question({
   const isCorrect = selectedAnswer === question.answer;
   
   const getDifficultyLabel = (d: number) => {
-    return '★'.repeat(d) + '☆'.repeat(3 - d);
+    return '★'.repeat(d) + '☆'.repeat(Math.max(0, 4 - d));
   };
 
   return (


### PR DESCRIPTION
- getDifficultyLabelで難易度4のとき負の数をrepeatに渡していた
- 星表示を4段階（★★★★）に対応