### PR TITLE
Handle empty quiz data safely

### DIFF
--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -5,7 +5,9 @@ interface ResultProps {
 }
 
 export function Result({ score, totalQuestions, onRetry }: ResultProps) {
-  const percentage = Math.round((score / totalQuestions) * 100);
+  const percentage = totalQuestions === 0
+    ? 0
+    : Math.round((score / totalQuestions) * 100);
   
   const getMessage = () => {
     if (percentage === 100) return { title: 'PERFECT!', sub: 'カメラマスター！' };

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -13,16 +13,18 @@ function shuffleArray<T>(array: T[]): T[] {
   return shuffled;
 }
 
+const initialState: QuizState = {
+  phase: 'start',
+  questions: [],
+  currentIndex: 0,
+  score: 0,
+  selectedAnswer: null,
+  showExplanation: false,
+  answers: [],
+};
+
 export function useQuiz() {
-  const [state, setState] = useState<QuizState>({
-    phase: 'start',
-    questions: [],
-    currentIndex: 0,
-    score: 0,
-    selectedAnswer: null,
-    showExplanation: false,
-    answers: [],
-  });
+  const [state, setState] = useState<QuizState>(initialState);
 
   const startGame = useCallback((difficulty: DifficultyFilter = 'all') => {
     // 難易度でフィルタリング
@@ -30,6 +32,11 @@ export function useQuiz() {
     const filtered = difficulty === 'all'
       ? allQuestions
       : allQuestions.filter(q => q.difficulty === difficulty);
+
+    if (filtered.length === 0) {
+      setState(initialState);
+      return;
+    }
 
     // シャッフル
     const shuffled = shuffleArray(filtered);
@@ -84,15 +91,7 @@ export function useQuiz() {
   }, []);
 
   const resetGame = useCallback(() => {
-    setState({
-      phase: 'start',
-      questions: [],
-      currentIndex: 0,
-      score: 0,
-      selectedAnswer: null,
-      showExplanation: false,
-      answers: [],
-    });
+    setState(initialState);
   }, []);
 
   const currentQuestion = state.questions[state.currentIndex] || null;


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when starting a game but no questions match the selected difficulty.
- Avoid a divide-by-zero when computing the result percentage in the `Result` component.
- Reduce duplicated initial state setup across the quiz hook by centralizing it.
- Make resetting the game reuse the same canonical initial state.

### Description
- Introduced a shared `initialState: QuizState` and used it to initialize `useState` in `useQuiz` and in `resetGame`.
- Added a guard in `startGame` to short-circuit with `setState(initialState)` when `filtered.length === 0`.
- Updated `Result` to compute `percentage` as `totalQuestions === 0 ? 0 : Math.round((score / totalQuestions) * 100)` to avoid division by zero.
- Replaced inline initial-state objects with the shared `initialState` for clarity and maintainability.

### Testing
- No automated tests were executed for this change.
- No test runners or CI jobs were invoked as part of this update.
- Manual runtime verification was not documented as part of this PR.
- Linting/build steps were not run in the automated rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959412a0f7c8333a19bd7b2a6a30be8)