### PR TITLE
Add issue list for quiz question text review

### DIFF
--- a/issues/quiz-question-review.md
+++ b/issues/quiz-question-review.md
@@ -1,0 +1,11 @@
+# Quiz Question Text Review Issues
+
+## Issue 1: 「シャインプルーフの原理」の表記揺れ・誤記
+- **Location**: `src/data/questions.json` (id: 52)
+- **Problem**: 「シャインプルーフの原理」は一般的に「シャイムフルークの原理（Scheimpflug）」が正しい表記。誤記により学習者が混乱する恐れがある。
+- **Suggested Fix**: 問題文・解説・選択肢内の表記を「シャイムフルークの原理」に修正する。
+
+## Issue 2: APEX値の解説式が誤り
+- **Location**: `src/data/questions.json` (id: 70)
+- **Problem**: 解説の「Av=N×2=F値の関係」は誤り。正しくは `Av = log2(N^2)` で、Avが1増えるとF値は√2倍になる。
+- **Suggested Fix**: 式を正しいAPEXの定義に修正し、Av=5 → F5.6 の根拠が伝わるように書き換える。


### PR DESCRIPTION
### Motivation
- Review quiz question text for clarity and factual correctness after inspecting `src/data/questions.json`.
- Capture discovered wording and formula errors so they can be tracked and fixed in follow-up changes.

### Description
- Add `issues/quiz-question-review.md` containing a concise list of problems found in the quiz dataset.
- Document Issue 1 pointing to `src/data/questions.json` id `52` about a misspelling of the Scheimpflug principle (`シャイムフルークの原理`).
- Document Issue 2 pointing to `src/data/questions.json` id `70` about an incorrect APEX formula and note the correct relation `Av = log2(N^2)` and the `Av=5 → F5.6` explanation.

### Testing
- This is a content-only change and no automated tests were run.
- File creation was committed to the repository and is ready for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a7d3b743c83339eddae91f670f53d)